### PR TITLE
ci: update from upstream

### DIFF
--- a/.github/workflows/merge-from-upstream.yaml
+++ b/.github/workflows/merge-from-upstream.yaml
@@ -14,9 +14,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-              with:
-                  submodules: recursive
-                  fetch-depth: 1
             - name: Add remote and fetch
               run: |
                   git remote add upstream https://github.com/rust-lang/rust.git

--- a/.github/workflows/merge-from-upstream.yaml
+++ b/.github/workflows/merge-from-upstream.yaml
@@ -1,4 +1,4 @@
-name: Update from Upstream
+name: Update Upstream Branch
 
 permissions:
     contents: write
@@ -14,6 +14,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
+              with:
+                  ref: upstream
             - name: Add remote and fetch
               run: |
                   git remote add upstream https://github.com/rust-lang/rust.git
@@ -21,7 +23,8 @@ jobs:
             - name: Create a branch that equals upstream master
               id: create-branch
               run: |
-                  git checkout -B upstream upstream/master
+                  git checkout -B upstream upstream/master || true
+                  git reset upstream/master --hard
             - name: Push to local
               run: |
                   git push -u origin upstream

--- a/.github/workflows/merge-from-upstream.yaml
+++ b/.github/workflows/merge-from-upstream.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     update-versions:
-        name: Merge and Open PR
+        name: Upstream Upstream Branch
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/merge-from-upstream.yaml
+++ b/.github/workflows/merge-from-upstream.yaml
@@ -25,4 +25,4 @@ jobs:
                   git reset upstream/master --hard
             - name: Push to local
               run: |
-                  git push -u origin upstream
+                  git push -f -u origin upstream

--- a/.github/workflows/merge-from-upstream.yaml
+++ b/.github/workflows/merge-from-upstream.yaml
@@ -1,0 +1,30 @@
+name: Update from Upstream
+
+permissions:
+    contents: write
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "0 0/4 * * *" # Every 4 hours
+
+jobs:
+    update-versions:
+        name: Merge and Open PR
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  submodules: recursive
+                  fetch-depth: 1
+            - name: Add remote and fetch
+              run: |
+                  git remote add upstream https://github.com/rust-lang/rust.git
+                  git fetch upstream master
+            - name: Create a branch that equals upstream master
+              id: create-branch
+              run: |
+                  git checkout -B upstream upstream/master
+            - name: Push to local
+              run: |
+                  git push -u origin upstream

--- a/.github/workflows/merge-from-upstream.yaml
+++ b/.github/workflows/merge-from-upstream.yaml
@@ -20,10 +20,8 @@ jobs:
               run: |
                   git remote add upstream https://github.com/rust-lang/rust.git
                   git fetch upstream master
-            - name: Create a branch that equals upstream master
-              id: create-branch
+            - name: Reset to upstream/master
               run: |
-                  git checkout -B upstream upstream/master || true
                   git reset upstream/master --hard
             - name: Push to local
               run: |


### PR DESCRIPTION
This will automatically update the `upstream` branch every 4 hours to reflect `rust-lang/rust`.

The `upstream` branch needs to be initialized prior to merging this PR (what it points to doesn't matter).