### PR TITLE
Changed old link and content inside "Getting Help" Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ build environments that are most likely to work.
 
 ## Getting Help
 
-See https://www.crablang.org/community for a list of chat platforms and forums.
+Need help? Join us on discord at https://community.crablang.org! 
 
 ## Contributing
 


### PR DESCRIPTION
https://www.crablang.org/community seems to have been changed to https://community.crablang.org pointing to the discord server.