### PR TITLE
Add feature to disable the standard library’s panic_impl

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -69,6 +69,9 @@ system-llvm-libunwind = ["unwind/system-llvm-libunwind"]
 # Make panics and failed asserts immediately abort without formatting any message
 panic_immediate_abort = ["core/panic_immediate_abort"]
 
+# Disables the `panic_impl` lang item
+no_panic_impl = []
+
 # Enable std_detect default features for stdarch/crates/std_detect:
 # https://github.com/rust-lang/stdarch/blob/master/crates/std_detect/Cargo.toml
 std_detect_file_io = ["std_detect/std_detect_file_io"]

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -522,7 +522,7 @@ pub fn panicking() -> bool {
 
 /// Entry point of panics from the core crate (`panic_impl` lang item).
 #[cfg(not(test))]
-#[panic_handler]
+#[cfg_attr(not(feature = "no_panic_impl"), panic_handler)]
 pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
     struct PanicPayload<'a> {
         inner: &'a fmt::Arguments<'a>,


### PR DESCRIPTION
From [rust-lang/rust#100156](https://github.com/rust-lang/rust/pull/100156).