### PR TITLE
use our crabgo repo as the submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/rust-lang/nomicon.git
 [submodule "src/tools/cargo"]
 	path = src/tools/cargo
-	url = https://github.com/rust-lang/cargo.git
+	url = https://github.com/crablang/crabgo.git
 [submodule "src/doc/reference"]
 	path = src/doc/reference
 	url = https://github.com/rust-lang/reference.git


### PR DESCRIPTION
crabgo is built as part of the compiler build, so we need to update its submodule to use our repo instead of upstream. we'll need to do the same for others in the future.