### PR TITLE
update sync script

### DIFF
--- a/sync-upstream.sh
+++ b/sync-upstream.sh
@@ -1,14 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# check if we're on the "current" branch, and if not, switch to it
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$current_branch" != "current" ]; then
+# check if we're on the "upstream" branch, and if not, switch to it
+upstream_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$upstream_branch" != "upstream" ]; then
     # check if the branch already exists locally
-    git branch | grep -q current
+    git branch | grep -q upstream
     if [ $? -ne 0 ]; then
-      git checkout -b current
+        git checkout master
+      git checkout -b upstream
     else
-      git checkout current
+      git checkout upstream
     fi
 fi
 
@@ -22,12 +23,27 @@ fi
 git fetch upstream
 git reset --hard upstream/master
 
+# check if we're on the "current" branch, and if not, switch to it
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "current" ]; then
+    # check if the branch already exists locally
+    git branch | grep -q current
+    if [ $? -ne 0 ]; then
+      git checkout master
+      git checkout -b current
+    else
+      git checkout current
+      git reset --hard master
+    fi
+fi
+
 # copy the README.md file from the local master branch
-git checkout master -- README.md CODE_OF_CONDUCT.md CONTRIBUTING.md sync-upstream.sh
+# git checkout master -- README.md CODE_OF_CONDUCT.md CONTRIBUTING.md sync-upstream.sh
+git rebase -Xtheirs upstream
 
 # add it to git in the current branch and create a commit
-git add --all
-git commit -m "incorporate stable changes"
+# git add --all
+# git commit -m "incorporate stable changes"
 
 # git push git paid
-git push --force origin current
+# git push --force origin current

--- a/sync-upstream.sh
+++ b/sync-upstream.sh
@@ -16,6 +16,11 @@ if ! git remote | grep -q upstream; then
     git remote add upstream https://github.com/rust-lang/rust.git || echo "Failed to add upstream remote" && exit 1
 fi
 
+# add the remote "origin" if it doesn't exist
+if ! git remote | grep -q origin; then
+    git remote add origin https://github.com/crablang/crab.git || echo "Failed to add origin remote" && exit 1
+fi
+
 # hard reset to the remote "upstream" and branch "master"
 git fetch upstream || echo "Failed to fetch upstream" && exit 1
 git reset --hard upstream/master || echo "Failed to reset to upstream/master" && exit 1
@@ -31,18 +36,10 @@ if [ "$current_branch" != "current" ]; then
     fi
 fi
 
-git reset --hard master || echo "Failed to reset \"current\" to local \"master\"" && exit 1
+git reset --hard origin/master || echo "Failed to reset local \"current\" to remote crab \"master\"" && exit 1
 
 # rebase the local "current" branch to the local "upstream" branch, favoring the "current" branch
 git rebase -Xtheirs upstream || echo "Failed to rebase \"current\" with \"upstream\"" && exit 1
-
-
-# make sure we are on the "current" branch
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$current_branch" != "current" ]; then
-    echo "Not on \"current\" branch, aborting"
-    exit 1
-fi
 
 # push the changes to the remote "current" branch
 git push --force origin current || echo "Failed to push \"current\" to remote" && exit 1

--- a/sync-upstream.sh
+++ b/sync-upstream.sh
@@ -1,49 +1,49 @@
 #!/usr/bin/env bash
 
 # check if we're on the "upstream" branch, and if not, switch to it
-upstream_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$upstream_branch" != "upstream" ]; then
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "upstream" ]; then
     # check if the branch already exists locally
-    git branch | grep -q upstream
-    if [ $? -ne 0 ]; then
-        git checkout master
-      git checkout -b upstream
+    if ! git branch | grep -q upstream; then
+        git checkout -b upstream || echo "Failed to create and checkout upstream" && exit 1
     else
-      git checkout upstream
+        git checkout upstream || echo "Failed to checkout upstream" && exit 1
     fi
 fi
 
 # add the remote "upstream" if it doesn't exist
-git remote | grep -q upstream
-if [ $? -ne 0 ]; then
-  git remote add upstream https://github.com/rust-lang/rust.git
+if ! git remote | grep -q upstream; then
+    git remote add upstream https://github.com/rust-lang/rust.git || echo "Failed to add upstream remote" && exit 1
 fi
 
 # hard reset to the remote "upstream" and branch "master"
-git fetch upstream
-git reset --hard upstream/master
+git fetch upstream || echo "Failed to fetch upstream" && exit 1
+git reset --hard upstream/master || echo "Failed to reset to upstream/master" && exit 1
 
 # check if we're on the "current" branch, and if not, switch to it
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [ "$current_branch" != "current" ]; then
     # check if the branch already exists locally
-    git branch | grep -q current
-    if [ $? -ne 0 ]; then
-      git checkout master
-      git checkout -b current
+    if ! git branch | grep -q current; then
+        git checkout -b current || echo "Failed to create and checkout current" && exit 1
     else
-      git checkout current
-      git reset --hard master
+        git checkout current || echo "Failed to checkout current" && exit 1
     fi
 fi
 
-# copy the README.md file from the local master branch
-# git checkout master -- README.md CODE_OF_CONDUCT.md CONTRIBUTING.md sync-upstream.sh
-git rebase -Xtheirs upstream
+git reset --hard master || echo "Failed to reset \"current\" to local \"master\"" && exit 1
 
-# add it to git in the current branch and create a commit
-# git add --all
-# git commit -m "incorporate stable changes"
+# rebase the local "current" branch to the local "upstream" branch, favoring the "current" branch
+git rebase -Xtheirs upstream || echo "Failed to rebase \"current\" with \"upstream\"" && exit 1
 
-# git push git paid
-# git push --force origin current
+
+# make sure we are on the "current" branch
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "current" ]; then
+    echo "Not on \"current\" branch, aborting"
+    exit 1
+fi
+
+# push the changes to the remote "current" branch
+git push --force origin current || echo "Failed to push \"current\" to remote" && exit 1
+


### PR DESCRIPTION
uses `git rebase -Xtheirs` instead of checking out files on top of `git reset --hard`

this way we don't need to keep track of individual changed files, and relevant upstream changes can be merged into the same files.

this will come with its own set of challenges, but should ultimately be a better approach, as @lleyton's suggested.