### PR TITLE
rename output binary

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1128,7 +1128,7 @@ impl<'a> Builder<'a> {
         if compiler.is_snapshot(self) {
             self.initial_rustc.clone()
         } else {
-            self.sysroot(compiler).join("bin").join(exe("rustc", compiler.host))
+            self.sysroot(compiler).join("bin").join(exe("crabc", compiler.host))
         }
     }
 


### PR DESCRIPTION
changed output binary name from rustc to crabc

built stage 2 successfully
passed all stage 2 ui tests

```sh
./x.py test tests/ui --bless --stage 2
test result: ok. 6 passed; 0 failed; 15087 ignored; 0 measured; 0 filtered out; finished in 891.61ms
```